### PR TITLE
NEXUS-3442: Fix

### DIFF
--- a/restlet-1.1.6-5346-sonatype/modules/com.noelios.restlet/src/com/noelios/restlet/http/HttpServerConverter.java
+++ b/restlet-1.1.6-5346-sonatype/modules/com.noelios.restlet/src/com/noelios/restlet/http/HttpServerConverter.java
@@ -407,7 +407,7 @@ public class HttpServerConverter extends HttpConverter {
                 }
             } else {
                 getLogger().log(Level.WARNING,
-                                "An exception occured writing the response entity: " + e.getMessage());
+                                "An exception occured writing the response entity: " + e.getMessage(), e);
                 response.getHttpCall().setStatusCode(
                         Status.SERVER_ERROR_INTERNAL.getCode());
                 response.getHttpCall().setReasonPhrase(

--- a/restlet-1.1.6-5346-sonatype/modules/com.noelios.restlet/src/com/noelios/restlet/http/HttpServerConverter.java
+++ b/restlet-1.1.6-5346-sonatype/modules/com.noelios.restlet/src/com/noelios/restlet/http/HttpServerConverter.java
@@ -391,21 +391,16 @@ public class HttpServerConverter extends HttpConverter {
             // Send the response to the client
             response.getHttpCall().sendResponse(response);
         } catch (Exception e) {
-            if (response.getHttpCall().isConnectionBroken(e)) {
+            final Exception cause = e.getCause() != null && e.getCause() instanceof Exception ? (Exception) e.getCause() : null;
+            if (response.getHttpCall().isConnectionBroken(e) || (cause != null && response.getHttpCall().isConnectionBroken(cause))) {
                 getLogger()
                         .log(
-                                Level.INFO,
+                                Level.FINE,
                                 "The connection was broken. It was probably closed by the client.",
                                 e);
             } else {
-                if ( getLogger().isLoggable( Level.FINE ) ) {
-                    getLogger().log(Level.FINE,
-                                    "An exception occured writing the response entity:", e);
-                }
-                else {
-                    getLogger().log(Level.WARNING,
-                                    "An exception occured writing the response entity: " + e.getMessage());
-                }
+                getLogger().log(Level.WARNING,
+                                "An exception occured writing the response entity: " + e.getMessage());
                 response.getHttpCall().setStatusCode(
                         Status.SERVER_ERROR_INTERNAL.getCode());
                 response.getHttpCall().setReasonPhrase(

--- a/restlet-1.1.6-5346-sonatype/modules/com.noelios.restlet/src/com/noelios/restlet/http/HttpServerConverter.java
+++ b/restlet-1.1.6-5346-sonatype/modules/com.noelios.restlet/src/com/noelios/restlet/http/HttpServerConverter.java
@@ -458,8 +458,8 @@ public class HttpServerConverter extends HttpConverter {
             }
         } );
         getLogger().log( Level.INFO,
-                         "Connection broken, is probably closed by the client. UA=\"" + userAgentString + "\", URI=\""
-                             + uri + "\", IP=" + remoteIpAddress + ": " + e.getClass().getSimpleName() + ": "
+                         "Client closed connection early (UA=\"" + userAgentString + "\", URI=\""
+                             + uri + "\", IP=" + remoteIpAddress + "): " + e.getClass().getSimpleName() + ": "
                              + e.getMessage() );
     }
 

--- a/restlet-1.1.6-5346-sonatype/modules/com.noelios.restlet/src/com/noelios/restlet/http/HttpServerConverter.java
+++ b/restlet-1.1.6-5346-sonatype/modules/com.noelios.restlet/src/com/noelios/restlet/http/HttpServerConverter.java
@@ -480,7 +480,7 @@ public class HttpServerConverter extends HttpConverter {
             {
                 // ahem
                 getLogger().log( Level.WARNING,
-                                 "Connection broken, but problem occurred during log message preparation.",
+                                 "Client closed connection early, but problem occurred during log message preparation.",
                                  e );
             }
         }


### PR DESCRIPTION
Fixing the original patch:
- checking for current exception but for it's cause too (this should handle the Jetty case where exception we look for is actually wrapped)
- lowering the "client closed connection" log level (from INFO to FINE, is JUL!)
- Undoing the original patch, in case of "something very bad happened that is not client closed connection" we will have a stack trace
