### PR TITLE
Shut up logservice

### DIFF
--- a/restlet-1.1.6-5346-sonatype/modules/com.noelios.restlet/src/com/noelios/restlet/LogFilter.java
+++ b/restlet-1.1.6-5346-sonatype/modules/com.noelios.restlet/src/com/noelios/restlet/LogFilter.java
@@ -101,16 +101,18 @@ public class LogFilter extends Filter {
      */
     @Override
     protected void afterHandle(Request request, Response response) {
-        // Format the call into a log entry
-        if (this.logTemplate != null) {
-            this.logLogger.log(Level.INFO, format(request, response));
-        } else {
-            if (this.logLogger.isLoggable(Level.INFO)) {
-                final long startTime = (Long) request.getAttributes().get(
-                        "org.restlet.startTime");
-                final int duration = (int) (System.currentTimeMillis() - startTime);
-                this.logLogger.log(Level.INFO, formatDefault(request, response,
-                        duration));
+        if (logService.isEnabled()) {
+            // Format the call into a log entry
+            if (this.logTemplate != null) {
+                this.logLogger.log(Level.INFO, format(request, response));
+            } else {
+                if (this.logLogger.isLoggable(Level.INFO)) {
+                    final long startTime = (Long) request.getAttributes().get(
+                            "org.restlet.startTime");
+                    final int duration = (int) (System.currentTimeMillis() - startTime);
+                    this.logLogger.log(Level.INFO, formatDefault(request, response,
+                            duration));
+                }
             }
         }
     }

--- a/restlet-1.1.6-5346-sonatype/modules/com.noelios.restlet/src/com/noelios/restlet/http/HttpServerConverter.java
+++ b/restlet-1.1.6-5346-sonatype/modules/com.noelios.restlet/src/com/noelios/restlet/http/HttpServerConverter.java
@@ -457,10 +457,28 @@ public class HttpServerConverter extends HttpConverter {
                 return findIP( request );
             }
         } );
+        final String processingTime = calculateProcessingTime( request );
         getLogger().log( Level.INFO,
-                         "Client closed connection early (UA=\"" + userAgentString + "\", URI=\""
+                         "Client closed connection early (processingTime="+processingTime+"ms, UA=\"" + userAgentString + "\", URI=\""
                              + uri + "\", IP=" + remoteIpAddress + "): " + e.getClass().getSimpleName() + ": "
                              + e.getMessage() );
+    }
+
+    private String calculateProcessingTime( final Request request )
+    {
+        // this attribute is put in by LogFilter, so check for it's presence 1st
+        if ( request.getAttributes().containsKey( "org.restlet.startTime" ) )
+        {
+            final long startTime = (Long) request.getAttributes().get(
+                "org.restlet.startTime" );
+            final long duration = System.currentTimeMillis() - startTime;
+            return Long.toString( duration );
+        }
+        else
+        {
+            // LogFilter is not installed
+            return "n/a";
+        }
     }
 
     private String nvl( final Callable<String> callable )

--- a/restlet-1.1.6-5346-sonatype/modules/org.restlet/src/org/restlet/Component.java
+++ b/restlet-1.1.6-5346-sonatype/modules/org.restlet/src/org/restlet/Component.java
@@ -222,7 +222,10 @@ public class Component extends Restlet {
                     }
 
                 };
-                this.logService = new LogService(true);
+                // shutting down LogService by default
+                // still, enabling it is possible by having System property set as
+                // org.restlet.service.LogService=true
+                this.logService = new LogService(Boolean.getBoolean(LogService.class.getName().toString()));
                 this.statusService = new StatusService(true);
                 this.clients.setContext(getContext());
                 this.servers.setContext(getContext());


### PR DESCRIPTION
Restlet1.1 provides no means to shut down thing thing (see change).

LogService produces "access log" like log lines at INFO level,
pushing it to JUL (as Restlet 1.1 uses JUL). We never use this,
just makes logs noisy, and eats CPU time. If access log needed,
enable it on Jetty (in case of Nexus) or using the added
system property

org.restlet.service.LogService=true

Also, it turns out that in V5 modified HttpServerConverter
we do have access to request processing time, but only
if LogFilter is installed.

Extended log entry with processing time too, to
ease debugging, detecting problems.

See:
http://www.restlet.org/documentation/1.1/tutorial#part07
http://wiki.restlet.org/docs_1.1/13-restlet/27-restlet/48-restlet/101-restlet.html
